### PR TITLE
카테고리 정보 조회 API 성능 개선 작업

### DIFF
--- a/backend/src/main/java/com/dragontrain/md/common/config/BeanConfig.java
+++ b/backend/src/main/java/com/dragontrain/md/common/config/BeanConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.caffeine.CaffeineCache;
 import org.springframework.cache.support.SimpleCacheManager;
@@ -16,6 +17,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
 
 @RequiredArgsConstructor
 @Configuration
@@ -28,8 +30,10 @@ public class BeanConfig {
 		return new JPAQueryFactory(em);
 	}
 
-	@Bean
-	public CacheManager cacheManager() {
+
+	@Qualifier("caffeineCacheManager")
+	@Bean(name = "caffeineCacheManager")
+	public CacheManager caffeineCacheManager() {
 		SimpleCacheManager cacheManager = new SimpleCacheManager();
 
 		List<CaffeineCache> caches =
@@ -48,6 +52,8 @@ public class BeanConfig {
 		cacheManager.setCaches(caches);
 		return cacheManager;
 	}
+
+
 
 
 }

--- a/backend/src/main/java/com/dragontrain/md/common/config/CacheType.java
+++ b/backend/src/main/java/com/dragontrain/md/common/config/CacheType.java
@@ -6,7 +6,10 @@ import lombok.Getter;
 public enum CacheType {
 
 
-	CACTEGORY("category");
+	CATEGORY("category"),
+	USER("user")
+
+	;
 
 	private String name;
 	private Integer expireAfterWrite;

--- a/backend/src/main/java/com/dragontrain/md/common/config/RedisConfig.java
+++ b/backend/src/main/java/com/dragontrain/md/common/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -55,5 +56,18 @@ public class RedisConfig {
 	@Bean
 	public GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer() {
 		return new GenericJackson2JsonRedisSerializer();
+	}
+
+	@Primary
+	@Qualifier("redisCacheManager")
+	@Bean(name = "redisCacheManager")
+	public CacheManager redisCacheManager() {
+		RedisCacheManager.RedisCacheManagerBuilder builder = RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory());
+		RedisCacheConfiguration configuration = RedisCacheConfiguration.defaultCacheConfig()
+			.serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+			.prefixCacheNameWith("Cache:") // Key Prefix로 "Cache:"를 앞에 붙여 저장
+			.entryTtl(Duration.ofMinutes(30)); // 캐시 수명 30분
+		builder.cacheDefaults(configuration);
+		return builder.build();
 	}
 }

--- a/backend/src/main/java/com/dragontrain/md/common/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/dragontrain/md/common/config/WebMvcConfig.java
@@ -1,0 +1,16 @@
+package com.dragontrain.md.common.config;
+
+import com.dragontrain.md.common.config.utils.PerformanceInterceptor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(new PerformanceInterceptor())
+			.addPathPatterns("/**");
+	}
+}

--- a/backend/src/main/java/com/dragontrain/md/common/config/utils/PerformanceInterceptor.java
+++ b/backend/src/main/java/com/dragontrain/md/common/config/utils/PerformanceInterceptor.java
@@ -1,0 +1,29 @@
+package com.dragontrain.md.common.config.utils;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+@Slf4j
+public class PerformanceInterceptor implements HandlerInterceptor {
+
+	private ThreadLocal<Long> startTime = new ThreadLocal<>();
+
+	@Override
+	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+		long start = System.currentTimeMillis();
+		startTime.set(start);
+		return true;
+	}
+
+	@Override
+	public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) throws Exception {
+		Long st = this.startTime.get();
+		long endTime = System.currentTimeMillis();
+		log.info("[{}]{} {}ms", request.getMethod(), request.getRequestURI(), endTime - st);
+		startTime.remove();
+	}
+}

--- a/backend/src/main/java/com/dragontrain/md/domain/food/controller/FoodController.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/food/controller/FoodController.java
@@ -3,6 +3,7 @@ package com.dragontrain.md.domain.food.controller;
 import java.util.List;
 
 import com.dragontrain.md.domain.food.controller.response.*;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -44,9 +45,12 @@ public class FoodController {
 		return ResponseEntity.ok(foodService.getBarcodeInfo(barcode));
 	}
 
+
+
 	@GetMapping("/category")
 	public ResponseEntity<List<CategoryInfoResponse>> getCategoryInfo() {
 		return ResponseEntity.ok(foodService.getCategoryInfo());
+//		return ResponseEntity.ok().build();
 	}
 
 	@GetMapping("/expiration")

--- a/backend/src/main/java/com/dragontrain/md/domain/food/infra/CategoryBigJpaRepository.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/food/infra/CategoryBigJpaRepository.java
@@ -16,4 +16,7 @@ public interface CategoryBigJpaRepository extends JpaRepository<CategoryBig, Int
 		" where year(f.createdAt)=:year and month(f.createdAt)=:month")
 	List<BigCategoryPriceInfo> findAllBigGroupAndSpend(Long refrigeratorId, Integer year, Integer month);
 
+	@Query("select cb from CategoryBig cb left join fetch cb.categoryDetails")
+	List<CategoryBig> findAllCategory();
+
 }

--- a/backend/src/main/java/com/dragontrain/md/domain/food/infra/CategoryBigRepositoryImpl.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/food/infra/CategoryBigRepositoryImpl.java
@@ -20,7 +20,7 @@ public class CategoryBigRepositoryImpl implements CategoryBigRepository {
 
 	@Override
 	public List<CategoryBig> findAll() {
-		return categoryBigJpaRepository.findAll();
+		return categoryBigJpaRepository.findAllCategory();
 	}
 
 	@Override

--- a/backend/src/main/java/com/dragontrain/md/domain/food/service/FoodServiceImpl.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/food/service/FoodServiceImpl.java
@@ -303,9 +303,10 @@ public class FoodServiceImpl implements FoodService {
 
 	}
 
-	@Cacheable("category")
+	@Cacheable(cacheNames = "category", cacheManager="redisCacheManager")
 	@Override
 	public List<CategoryInfoResponse> getCategoryInfo() {
+		log.info("cache miss!");
 		List<CategoryInfoResponse> categoryInfoResponseList = new ArrayList<>();
 		for (CategoryBig categoryBig : categoryBigRepository.findAll()) {
 			List<CategoryInfoDetail> categoryInfoDetails = new ArrayList<>();

--- a/backend/src/main/java/com/dragontrain/md/domain/user/service/UserServiceImpl.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/user/service/UserServiceImpl.java
@@ -1,5 +1,7 @@
 package com.dragontrain.md.domain.user.service;
 
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +27,7 @@ public class UserServiceImpl implements UserService {
 	private final EventPublisher eventPublisher;
 	private final TimeService timeService;
 
+	@Cacheable(cacheNames = "user", key = "#userId", cacheManager = "caffeineCacheManager")
 	@Override
 	public User loadUserByUserId(Long userId) {
 		return userRepository.findById(userId)
@@ -50,6 +53,7 @@ public class UserServiceImpl implements UserService {
 		return Tokens.of(jwtProvider.createAccessToken(userId), jwtProvider.createRefreshToken(userId));
 	}
 
+	@CacheEvict(cacheNames = "user", key = "#user.userId")
 	@Transactional
 	@Override
 	public void signOut(User user) {


### PR DESCRIPTION
#1 에서 카테고리 정보 조회 API의 성능이 떨어진다는 것을 확인했었음.

이를 개선하려고 Redis를 활용해 캐싱 처리를 해주었고, Fetch join을 적용시켜 N+1 문제를 해결했다.

**원래 상태**

| VUser | TPS | MTT(ms) | Error Rate(%)|
|------|------|-----|-------------|
|1|8.8|133 | 0|
|4 | 25.2| 158| 0 |
| 40 | 40.5| 950| 0|
|400| 31.9| 9165| 0.1|
| 1200| 20| 6181| 0.5|
| 2000| 22.3 | 10,843 | 0|
| 4000 | 20.6 | 13,487| 45|
|12000 | 7.6 | 11,071 | 69 | 


**Fetch Join 적용**

| VUser | TPS | MTT(ms) | Error Rate(%)|
|------|------|-----|-------------|
|1|9.8|101.16 | 0|
|4 | 28| 143| 0 |
| 40 | 46.3| 833| 0|
|400| 33.5| 8643| 0.9|
| 1200| 31.2| 6531| 0.7|
| 2000| 26.6 | 6214 | 0.9|
| 4000 | 15.8 | 9551 | 62.1|
|12000 | 6.6 | 11,071 | 82.6 | 


**Caching 적용**

| VUser | TPS | MTT(ms) | Error Rate(%)|
|------|------|-----|-------------|
|1|10.7|93.3 | 0|
|4 | 26.5| 151.1 | 0 |
| 40 | 33.0| 1185| 0|
|400| 37.0| 5047| 0.0|
| 1200| 28.7| 8509| 0.2|
| 2000| 25.3 | 6905 | 4.3 |
| 4000 | 26.7 | 1606 | 0 |
|12000 | 21.7 | 4398  | 0 | 



성능 테스트하는 과정에서 ramp-up이 살짝 바뀌어서 부정확할 수는 있다. 캐싱을 적용한다고 뭔가 대단하게 TPS 자체가 상승되지는 않았다. 하지만 더 부하가 심해지는 상황에서도 에러율이 더 적게 발생하고 캐싱을 통해 VUser가 4000, 12000 상황에서도 충분히 대처가 가능하다는 것을 확인할 수 있었다.

만들어본 `PerformanceInterceptor`에 의하면 처음 상태의 로직 처리 속도는 20~40 ms, fetch join을 적용한 후는 10ms, 캐싱을 적용한 후는 1~3ms 정도로 개선된 것을 확인할 수 있었다.

 크게 성능이 개선되지 않는 이유로는 초당 response의 값을 확인할 수 있었는데, 다른 API인 바코드 정보 조회 API의 경우 KB수준인데, 이 API의 경우는 MB 수준의 리턴이 들어오고 있기 때문에, 전달되는 값 자체가 커서 문제가 발생하는 것이 아닌가 하는 생각이 들었다.