### PR TITLE
동시성 이슈 처리하기

### DIFF
--- a/backend/src/main/java/com/dragontrain/md/common/lock/LockRepository.java
+++ b/backend/src/main/java/com/dragontrain/md/common/lock/LockRepository.java
@@ -1,0 +1,8 @@
+package com.dragontrain.md.common.lock;
+
+public interface LockRepository {
+
+	Boolean getLock(String functionName,Object... key);
+
+	Boolean releaseLock(String functionName, Object... key);
+}

--- a/backend/src/main/java/com/dragontrain/md/common/lock/RedisLockRepositoryImpl.java
+++ b/backend/src/main/java/com/dragontrain/md/common/lock/RedisLockRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.dragontrain.md.common.lock;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Repository
+public class RedisLockRepositoryImpl implements LockRepository{
+
+	private final RedisTemplate<String, String> redisTemplate;
+	@Override
+	public Boolean getLock(String functionName, Object... key) {
+		return redisTemplate.opsForValue().setIfAbsent(generateKey(functionName, key), "lock", Duration.ofMillis(3000));
+	}
+	@Override
+	public Boolean releaseLock(String functionName, Object... key) {
+		return redisTemplate.delete(generateKey(functionName, key));
+	}
+
+	private String generateKey(String functionName, Object... key) {
+		StringBuilder sb = new StringBuilder();
+		sb.append("LOCK::").append(functionName).append("::");
+		for (Object k : key) {
+			sb.append(k.toString());
+		}
+		return sb.toString();
+	}
+
+}

--- a/backend/src/main/java/com/dragontrain/md/domain/food/controller/FoodController.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/food/controller/FoodController.java
@@ -1,5 +1,6 @@
 package com.dragontrain.md.domain.food.controller;
 
+import java.util.Arrays;
 import java.util.List;
 
 import com.dragontrain.md.domain.food.controller.response.*;
@@ -117,6 +118,7 @@ public class FoodController {
 		@PathVariable @Path(candidates = {"eaten", "thrown"}, message = "eaten, thrown의 값만 입력해주세요") String deleteType,
 		@RequestParam @NotNull @NotEmpty(message = "foodId를 1개 이상 보내야 합니다.") Long[] foodId,
 		@AuthenticationPrincipal User user) {
+		log.info("foodIds : {}", Arrays.toString(foodId));
 		foodService.deleteFood(deleteType, foodId, user);
 		return ResponseEntity.ok().build();
 	}

--- a/backend/src/main/java/com/dragontrain/md/domain/food/controller/FoodEventHandler.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/food/controller/FoodEventHandler.java
@@ -3,7 +3,6 @@ package com.dragontrain.md.domain.food.controller;
 import com.dragontrain.md.domain.food.event.EatenCountRaised;
 import com.dragontrain.md.domain.food.service.FoodService;
 import com.dragontrain.md.domain.user.event.UserDeleted;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;

--- a/backend/src/main/java/com/dragontrain/md/domain/food/exception/FoodErrorCode.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/food/exception/FoodErrorCode.java
@@ -19,6 +19,7 @@ public enum FoodErrorCode implements ErrorCode {
 	STORAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "저장고 종류를 찾을 수 없습니다"),
 	FOOD_NOT_FOUND(HttpStatus.NOT_FOUND, "식품 정보를 찾을 수 없습니다"),
 	CATEGORY_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "소분류를 찾을 수 없습니다"),
+	CATEGORY_BIG_NOT_FOUND(HttpStatus.NOT_FOUND, "대분류를 찾을 수 없습니다"),
 	EXPIRATION_DATE_NOT_FOUND(HttpStatus.NOT_FOUND, "예상 소비기한 정보가 존재하지 않습니다. 직접 기입해주세요"),
 	INVALID_ACCESS(HttpStatus.FORBIDDEN, "음식에 접근할 권한이 없습니다"),
 	ALREADY_DELETED_FOOD(HttpStatus.BAD_REQUEST, "이미 삭제된 음식입니다"),

--- a/backend/src/main/java/com/dragontrain/md/domain/food/infra/CategoryBigRepositoryImpl.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/food/infra/CategoryBigRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.dragontrain.md.domain.food.infra;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 
@@ -26,5 +27,10 @@ public class CategoryBigRepositoryImpl implements CategoryBigRepository {
 	@Override
 	public List<BigCategoryPriceInfo> findAllBigGroupAndSpend(Long refrigeratorId, Integer year, Integer month) {
 		return categoryBigJpaRepository.findAllBigGroupAndSpend(refrigeratorId, year, month);
+	}
+
+	@Override
+	public Optional<CategoryBig> findById(Integer id) {
+		return categoryBigJpaRepository.findById(id);
 	}
 }

--- a/backend/src/main/java/com/dragontrain/md/domain/food/service/FoodServiceImpl.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/food/service/FoodServiceImpl.java
@@ -366,6 +366,7 @@ public class FoodServiceImpl implements FoodService {
 		Long userId = user.getUserId();
 
 		// ids 중복 있는지 검증
+		log.info("foodIds : {}", Arrays.toString(foodIds));
 
 		validateDuplicateFoodIds(foodIds);
 

--- a/backend/src/main/java/com/dragontrain/md/domain/food/service/port/CategoryBigRepository.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/food/service/port/CategoryBigRepository.java
@@ -1,6 +1,7 @@
 package com.dragontrain.md.domain.food.service.port;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.dragontrain.md.domain.food.domain.CategoryBig;
 import com.dragontrain.md.domain.statistics.service.dto.BigCategoryPriceInfo;
@@ -10,4 +11,6 @@ public interface CategoryBigRepository {
 	List<CategoryBig> findAll();
 
 	List<BigCategoryPriceInfo> findAllBigGroupAndSpend(Long refrigeratorId, Integer year, Integer month);
+
+	Optional<CategoryBig> findById(Integer id);
 }

--- a/backend/src/main/java/com/dragontrain/md/domain/refrigerator/controller/RefrigeratorEventHandler.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/refrigerator/controller/RefrigeratorEventHandler.java
@@ -2,6 +2,7 @@ package com.dragontrain.md.domain.refrigerator.controller;
 
 import com.dragontrain.md.domain.refrigerator.event.ExpAcquired;
 import com.dragontrain.md.domain.refrigerator.event.GotBadge;
+import com.dragontrain.md.domain.refrigerator.facade.RefrigeratorLockFacade;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -23,6 +24,7 @@ public class RefrigeratorEventHandler {
 	private final RefrigeratorService refrigeratorService;
 	private final LevelService levelService;
 	private final StorageStorageDesignService storageStorageDesignService;
+	private final RefrigeratorLockFacade refrigeratorLockFacade;
 
 	@EventListener
 	public void handleUserCreatedEvent(UserCreated userCreated) {
@@ -37,12 +39,12 @@ public class RefrigeratorEventHandler {
 
 	@EventListener
 	public void handleGotBadgeEvent(GotBadge gotBadge) {
-		refrigeratorService.gotBadge(gotBadge.getUserId(), gotBadge.getCategoryBigId());
+		refrigeratorLockFacade.gotBadge(gotBadge.getUserId(), gotBadge.getCategoryBigId());
 	}
 
 	@TransactionalEventListener
 	public void handleExpAddedEvent(ExpAcquired expAcquired) {
-		levelService.acquireExp(expAcquired.getUserId(), expAcquired.getExp());
+		refrigeratorLockFacade.acquireExp(expAcquired.getUserId(), expAcquired.getExp());
 	}
 
 	@TransactionalEventListener

--- a/backend/src/main/java/com/dragontrain/md/domain/refrigerator/facade/RefrigeratorLockFacade.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/refrigerator/facade/RefrigeratorLockFacade.java
@@ -1,0 +1,48 @@
+package com.dragontrain.md.domain.refrigerator.facade;
+
+import com.dragontrain.md.common.lock.LockRepository;
+import com.dragontrain.md.domain.refrigerator.service.LevelService;
+import com.dragontrain.md.domain.refrigerator.service.RefrigeratorService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class RefrigeratorLockFacade {
+
+	private final LockRepository lockRepository;
+	private final RefrigeratorService refrigeratorService;
+	private final LevelService levelService;
+
+
+	public void acquireExp(Long userId, Integer exp){
+		while (!lockRepository.getLock("acquireExp", userId)) {
+			try {
+				Thread.sleep(100);
+			} catch (InterruptedException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		try{
+			levelService.acquireExp(userId, exp);
+		}finally {
+			lockRepository.releaseLock("acquireExp", userId);
+		}
+	}
+
+	public void gotBadge(Long userId, Integer categoryBigId){
+		while (!lockRepository.getLock("gotBadge", userId)) {
+			try {
+				Thread.sleep(100);
+			} catch (InterruptedException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		try{
+			refrigeratorService.gotBadge(userId, categoryBigId);
+		}finally {
+			lockRepository.releaseLock("gotBadge", userId);
+		}
+	}
+
+}

--- a/backend/src/main/java/com/dragontrain/md/domain/refrigerator/infra/RefrigeratorEatenCountJpaRepository.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/refrigerator/infra/RefrigeratorEatenCountJpaRepository.java
@@ -1,13 +1,16 @@
 package com.dragontrain.md.domain.refrigerator.infra;
 
 import com.dragontrain.md.domain.refrigerator.domain.RefrigeratorEatenCount;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface RefrigeratorEatenCountJpaRepository extends JpaRepository<RefrigeratorEatenCount, Long> {
 
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
 	@Query("SELECT rec FROM RefrigeratorEatenCount rec" +
 		" WHERE rec.refrigeratorCategoryBigId.refrigeratorId = :refrigeratorId" +
 		" AND rec.refrigeratorCategoryBigId.categoryBigId = :categoryBigId")

--- a/backend/src/main/java/com/dragontrain/md/domain/refrigerator/service/LevelServiceImpl.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/refrigerator/service/LevelServiceImpl.java
@@ -47,7 +47,7 @@ public class LevelServiceImpl implements LevelService {
 	@Transactional(propagation = Propagation.REQUIRES_NEW)
 	@Override
 	public void acquireExp(Long userId, Integer exp) {
-		log.debug("acquireExp - userId : {}, exp : {}", userId, exp);
+		log.info("acquireExp - userId : {}, exp : {}", userId, exp);
 		Refrigerator refrigerator = refrigeratorRepository.findByUserId(userId)
 			.orElseThrow(() -> new RefrigeratorException(RefrigeratorErrorCode.REFRIGERATOR_NOT_FOUND));
 
@@ -67,7 +67,6 @@ public class LevelServiceImpl implements LevelService {
 			eventPublisher.publish(new LevelUp(userId, originLevel,  afterLevel));
 		}
 
-		log.debug("acquireExp - finished");
 	}
 
 	private AcquireExpCalculateResult calculateExp(int calculatedExp, Level level) {

--- a/backend/src/test/java/com/dragontrain/md/domain/food/infra/CategoryBigJpaRepositoryTest.java
+++ b/backend/src/test/java/com/dragontrain/md/domain/food/infra/CategoryBigJpaRepositoryTest.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import com.dragontrain.md.setting.JpaTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -26,7 +27,7 @@ import com.dragontrain.md.domain.user.domain.User;
 import com.dragontrain.md.domain.user.infra.UserJpaRepository;
 
 @DataJpaTest
-class CategoryBigJpaRepositoryTest {
+class CategoryBigJpaRepositoryTest extends JpaTest {
 
 	@Autowired
 	private UserJpaRepository userJpaRepository;

--- a/backend/src/test/java/com/dragontrain/md/domain/food/infra/FoodJpaRepositoryTest.java
+++ b/backend/src/test/java/com/dragontrain/md/domain/food/infra/FoodJpaRepositoryTest.java
@@ -2,6 +2,7 @@ package com.dragontrain.md.domain.food.infra;
 
 import java.time.LocalDateTime;
 
+import com.dragontrain.md.setting.JpaTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ import com.dragontrain.md.domain.user.domain.User;
 import com.dragontrain.md.domain.user.infra.UserJpaRepository;
 
 @DataJpaTest
-class FoodJpaRepositoryTest {
+class FoodJpaRepositoryTest extends JpaTest {
 
 	@Autowired
 	private UserJpaRepository userJpaRepository;

--- a/backend/src/test/java/com/dragontrain/md/domain/notice/infra/NoticeJpaRepositoryTest.java
+++ b/backend/src/test/java/com/dragontrain/md/domain/notice/infra/NoticeJpaRepositoryTest.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.dragontrain.md.setting.JpaTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,7 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
 import com.dragontrain.md.setting.TestEntityFactory;
 
 @DataJpaTest
-class NoticeJpaRepositoryTest {
+class NoticeJpaRepositoryTest extends JpaTest {
 
 	@Autowired
 	private NoticeJpaRepository noticeJpaRepository;


### PR DESCRIPTION
#2

경험치 획득, 먹은 개수 카운팅 상황에서 동시성 이슈가 발생하고 있었음.

해당 부분을 Redis를 활용한 lock과 비관락(배타락)을 이용해 처리해주었다.