### PR TITLE
feat: 바코드 정보 조회 캐싱

### DIFF
--- a/backend/src/main/java/com/dragontrain/md/common/config/BeanConfig.java
+++ b/backend/src/main/java/com/dragontrain/md/common/config/BeanConfig.java
@@ -31,7 +31,7 @@ public class BeanConfig {
 	}
 
 
-	@Qualifier("caffeineCacheManager")
+	@Primary
 	@Bean(name = "caffeineCacheManager")
 	public CacheManager caffeineCacheManager() {
 		SimpleCacheManager cacheManager = new SimpleCacheManager();

--- a/backend/src/main/java/com/dragontrain/md/common/config/CacheType.java
+++ b/backend/src/main/java/com/dragontrain/md/common/config/CacheType.java
@@ -7,7 +7,8 @@ public enum CacheType {
 
 
 	CATEGORY("category"),
-	USER("user")
+	USER("user"),
+	BARCODE("barcode"),
 
 	;
 

--- a/backend/src/main/java/com/dragontrain/md/common/config/RedisConfig.java
+++ b/backend/src/main/java/com/dragontrain/md/common/config/RedisConfig.java
@@ -58,8 +58,7 @@ public class RedisConfig {
 		return new GenericJackson2JsonRedisSerializer();
 	}
 
-	@Primary
-	@Qualifier("redisCacheManager")
+
 	@Bean(name = "redisCacheManager")
 	public CacheManager redisCacheManager() {
 		RedisCacheManager.RedisCacheManagerBuilder builder = RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory());

--- a/backend/src/main/java/com/dragontrain/md/common/config/security/WebSecurityConfig.java
+++ b/backend/src/main/java/com/dragontrain/md/common/config/security/WebSecurityConfig.java
@@ -69,7 +69,9 @@ public class WebSecurityConfig {
 			.authorizeHttpRequests((auth) ->
 				auth.requestMatchers("/h2-console/**", "/oauth2/**", "/login/**",
 						"/api/users/login-fail", "/api/users/reissue", "/actuator/**").permitAll()
-					.anyRequest().authenticated())
+//					.anyRequest().permitAll()
+					.anyRequest().authenticated()
+			)
 			.oauth2Login(config ->
 				config.userInfoEndpoint(c -> c.userService(customOAuth2Service))
 					.authorizationEndpoint(c -> c.authorizationRequestRepository(redisAuthorizationRequestRepository))

--- a/backend/src/main/java/com/dragontrain/md/domain/food/controller/FoodController.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/food/controller/FoodController.java
@@ -51,7 +51,6 @@ public class FoodController {
 	@GetMapping("/category")
 	public ResponseEntity<List<CategoryInfoResponse>> getCategoryInfo() {
 		return ResponseEntity.ok(foodService.getCategoryInfo());
-//		return ResponseEntity.ok().build();
 	}
 
 	@GetMapping("/expiration")

--- a/backend/src/main/java/com/dragontrain/md/domain/food/controller/response/BarcodeInfo.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/food/controller/response/BarcodeInfo.java
@@ -3,18 +3,16 @@ package com.dragontrain.md.domain.food.controller.response;
 import com.dragontrain.md.domain.food.domain.Barcode;
 import com.dragontrain.md.domain.food.domain.CategoryDetail;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 
 @Builder
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@NoArgsConstructor
 @Getter
 public class BarcodeInfo {
-	private final String name;
-	private final Integer categoryId;
-	private final Integer categoryBigId;
+	private  String name;
+	private  Integer categoryId;
+	private  Integer categoryBigId;
 
 	public static BarcodeInfo create(Barcode barcode) {
 		CategoryDetail categoryDetail = barcode.getCategoryDetail();

--- a/backend/src/main/java/com/dragontrain/md/domain/food/service/FoodServiceImpl.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/food/service/FoodServiceImpl.java
@@ -425,11 +425,10 @@ public class FoodServiceImpl implements FoodService {
 	}
 
 
-
+	@Cacheable(cacheNames = "barcode", cacheManager = "redisCacheManager")
 	@Transactional
 	@Override
 	public BarcodeInfo getBarcodeInfo(Long barcode) {
-
 		Barcode barcodeInfo = barcodeRepository.findByBarcodeId(barcode)
 			.orElseGet(() -> {
 				log.info("create new barcode entity barcode number : {}", barcode);
@@ -448,7 +447,6 @@ public class FoodServiceImpl implements FoodService {
 
 		return BarcodeInfo.create(barcodeInfo);
 	}
-
 	@Override
 	public ExpectedExpirationDate getExpectedExpirationDate(int categoryDetailId, int year, int month, int day) {
 		// 일단 날짜 만들기


### PR DESCRIPTION
바코드 정보 조회 상황에 캐싱을 도입해서 성능 개선이 가능해보였다. 

카페인 캐시, 레디스 캐시를 적용했을 때의 성능 비교를 진행해봤고, 카페인 캐시의 성능이 훌륭하지만, 중복되는 데이터 낭비를 줄이기 위해서 레디스 캐시를 적용해주었다.

### 결과

![image](https://github.com/kgh2120/hybm/assets/76154390/ccc4c937-470f-4378-8052-8b42d2a48258)
