### PR TITLE
feat: 카테고리 조회 API 캐싱

### DIFF
--- a/backend/src/main/java/com/dragontrain/md/domain/food/controller/FoodController.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/food/controller/FoodController.java
@@ -47,7 +47,7 @@ public class FoodController {
 	}
 
 
-
+	@Cacheable(cacheNames = "category", cacheManager = "caffeineCacheManager")
 	@GetMapping("/category")
 	public ResponseEntity<List<CategoryInfoResponse>> getCategoryInfo() {
 		return ResponseEntity.ok(foodService.getCategoryInfo());

--- a/backend/src/main/java/com/dragontrain/md/domain/food/service/FoodServiceImpl.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/food/service/FoodServiceImpl.java
@@ -302,8 +302,6 @@ public class FoodServiceImpl implements FoodService {
 		}
 
 	}
-
-	@Cacheable(cacheNames = "category", cacheManager="redisCacheManager")
 	@Override
 	public List<CategoryInfoResponse> getCategoryInfo() {
 		log.info("cache miss!");


### PR DESCRIPTION
카테고리 조회 API에도 카페인 캐싱을 적용해줬습니다.

이전에 할 때 발생한 오류에 대해서 정확한 원인을 몰라서 캐싱의 효율이 안나온다고 생각했었네요.

![image](https://github.com/kgh2120/hybm/assets/76154390/3d1b4eec-8c18-424a-90f3-fdaecd4fbf7e)
