### PR TITLE
Redis Lock에서 Optimistic Lock으로 전환 작업

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -63,6 +63,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     // fcm
     implementation 'com.google.firebase:firebase-admin:9.2.0'
+    // aop
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/backend/src/main/java/com/dragontrain/md/common/config/BeanConfig.java
+++ b/backend/src/main/java/com/dragontrain/md/common/config/BeanConfig.java
@@ -17,8 +17,10 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Primary;
 
+@EnableAspectJAutoProxy
 @RequiredArgsConstructor
 @Configuration
 public class BeanConfig {

--- a/backend/src/main/java/com/dragontrain/md/common/config/aop/OptimisticLock.java
+++ b/backend/src/main/java/com/dragontrain/md/common/config/aop/OptimisticLock.java
@@ -1,0 +1,19 @@
+package com.dragontrain.md.common.config.aop;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.core.annotation.Order;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OptimisticLock {
+	@AliasFor("threadSleepTime")
+	int value() default 50;
+	@AliasFor("value")
+	int threadSleepTime() default 50;
+
+}

--- a/backend/src/main/java/com/dragontrain/md/common/config/aop/OptimisticLockAspect.java
+++ b/backend/src/main/java/com/dragontrain/md/common/config/aop/OptimisticLockAspect.java
@@ -1,0 +1,31 @@
+package com.dragontrain.md.common.config.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class OptimisticLockAspect {
+
+	@Around("@annotation(optimisticLock)")
+	public Object logExecution(ProceedingJoinPoint joinPoint, OptimisticLock optimisticLock) {
+		while (true) {
+			try{
+				return joinPoint.proceed();
+			} catch (ObjectOptimisticLockingFailureException e) {
+				try {
+					Thread.sleep(optimisticLock.threadSleepTime());
+				} catch (InterruptedException ex) {
+					throw new RuntimeException(ex);
+				}
+			} catch (Throwable e) {
+				throw new RuntimeException(e);
+			}
+		}
+	}
+}

--- a/backend/src/main/java/com/dragontrain/md/domain/refrigerator/domain/Refrigerator.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/refrigerator/domain/Refrigerator.java
@@ -7,16 +7,7 @@ import com.dragontrain.md.domain.refrigerator.exception.RefrigeratorErrorCode;
 import com.dragontrain.md.domain.refrigerator.exception.RefrigeratorException;
 import com.dragontrain.md.domain.user.domain.User;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -57,6 +48,9 @@ public class Refrigerator {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "level_id")
 	private Level level;
+
+	@Version
+	private long version;
 
 	public static Refrigerator create(User user, Level level, LocalDateTime now) {
 		return Refrigerator.builder()

--- a/backend/src/main/java/com/dragontrain/md/domain/refrigerator/domain/Refrigerator.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/refrigerator/domain/Refrigerator.java
@@ -50,7 +50,7 @@ public class Refrigerator {
 	private Level level;
 
 	@Version
-	private long version;
+	private Long version;
 
 	public static Refrigerator create(User user, Level level, LocalDateTime now) {
 		return Refrigerator.builder()

--- a/backend/src/main/java/com/dragontrain/md/domain/refrigerator/facade/RefrigeratorLockFacade.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/refrigerator/facade/RefrigeratorLockFacade.java
@@ -3,7 +3,9 @@ package com.dragontrain.md.domain.refrigerator.facade;
 import com.dragontrain.md.common.lock.LockRepository;
 import com.dragontrain.md.domain.refrigerator.service.LevelService;
 import com.dragontrain.md.domain.refrigerator.service.RefrigeratorService;
+import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
@@ -16,17 +18,18 @@ public class RefrigeratorLockFacade {
 
 
 	public void acquireExp(Long userId, Integer exp){
-		while (!lockRepository.getLock("acquireExp", userId)) {
-			try {
-				Thread.sleep(100);
-			} catch (InterruptedException e) {
-				throw new RuntimeException(e);
+		while (true) {
+			try{
+				levelService.acquireExp(userId, exp);
+				break;
+			} catch (OptimisticLockException | ObjectOptimisticLockingFailureException e) {
+				try {
+					Thread.sleep(50);
+				} catch (InterruptedException ex) {
+					throw new RuntimeException(ex);
+				}
 			}
-		}
-		try{
-			levelService.acquireExp(userId, exp);
-		}finally {
-			lockRepository.releaseLock("acquireExp", userId);
+
 		}
 	}
 

--- a/backend/src/main/java/com/dragontrain/md/domain/refrigerator/facade/RefrigeratorLockFacade.java
+++ b/backend/src/main/java/com/dragontrain/md/domain/refrigerator/facade/RefrigeratorLockFacade.java
@@ -1,13 +1,14 @@
 package com.dragontrain.md.domain.refrigerator.facade;
 
+import com.dragontrain.md.common.config.aop.OptimisticLock;
 import com.dragontrain.md.common.lock.LockRepository;
 import com.dragontrain.md.domain.refrigerator.service.LevelService;
 import com.dragontrain.md.domain.refrigerator.service.RefrigeratorService;
-import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @RequiredArgsConstructor
 @Component
 public class RefrigeratorLockFacade {
@@ -16,24 +17,12 @@ public class RefrigeratorLockFacade {
 	private final RefrigeratorService refrigeratorService;
 	private final LevelService levelService;
 
-
-	public void acquireExp(Long userId, Integer exp){
-		while (true) {
-			try{
-				levelService.acquireExp(userId, exp);
-				break;
-			} catch (OptimisticLockException | ObjectOptimisticLockingFailureException e) {
-				try {
-					Thread.sleep(50);
-				} catch (InterruptedException ex) {
-					throw new RuntimeException(ex);
-				}
-			}
-
-		}
+	@OptimisticLock
+	public void acquireExp(Long userId, Integer exp) {
+		levelService.acquireExp(userId, exp);
 	}
 
-	public void gotBadge(Long userId, Integer categoryBigId){
+	public void gotBadge(Long userId, Integer categoryBigId) {
 		while (!lockRepository.getLock("gotBadge", userId)) {
 			try {
 				Thread.sleep(100);
@@ -41,9 +30,9 @@ public class RefrigeratorLockFacade {
 				throw new RuntimeException(e);
 			}
 		}
-		try{
+		try {
 			refrigeratorService.gotBadge(userId, categoryBigId);
-		}finally {
+		} finally {
 			lockRepository.releaseLock("gotBadge", userId);
 		}
 	}


### PR DESCRIPTION
# 요약
#2 이때 진행했던 동시성 처리 작업에 대해서, 각 방법에 대한 성능 평가 결과 Optimistic Lock을 이용하는 것이 더 좋다는 결론이 나와 해당 방법으로 전환. Optimistic Lock 사용을 위한 부수적인 처리에 대해서는 AOP를 활용해서 일괄 처리를 해줌.

---

## 작업

1. `Refrigerator.java` 클래스에 `version` 필드 추가. 그리고 Optimistic Lock 활용을 위해 `@Version` 어노테이션을 추가.
2. `OptimisticLock.java` 어노테이션 추가 및 `OptimisticLockAspect.java` 추가. 
    AOP 활용을 위해 `spring-boot-starter-aop` 의존성을 추가했다. Aspect 클래스 내부에서는 Optimistic Lock 충돌 시 retry 하는 로직을 넣어주었다. 그리고 기존 Redis Lock을 활용하던 Facade 클래스에서 Optimistic Lock으로 전환해주었다.

- [x] Build 동작 확인
- [x] API 동작 확인
- [x] 동시성 문제 제거 확인